### PR TITLE
Fix runtests and add unconstrained tests.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,40 @@
 using OptimTests, Optim
 using Base.Test
 
-options = OptimizationOptions()
-problems = CUTEst.select(max_var=100,max_con=100,custom_filter=x->x["derivative_order"]>=2)
-results = Dict{String,Any}()
-for prob in problems
+# unconstrained
+unc_problems = CUTEst.select(max_var=10,contype = :unc, custom_filter=x->x["derivative_order"]>=2)
+unc_results = Dict{String,Any}()
+for prob in unc_problems
     local result
     @show prob
     try
-        result = solve_problem(prob, options)
+        result = solve_problem(prob, GradientDescent())
     catch
-        results[prob] = "failed"
+        unc_results[prob] = "failed"
         continue
     end
     if result == Inf
         println("Initial point is not in the interior")
         continue
     end
-    results[prob] = (Optim.converged(result), result.minimum, solution_optimum(prob), result.iterations, result.f_calls)
+    unc_results[prob] = (Optim.converged(result), result.minimum, solution_optimum(prob), result.iterations, result.f_calls)
+end
+
+# constrained
+con_problems = CUTEst.select(max_var=100,max_con=100,custom_filter=x->x["derivative_order"]>=2)
+con_results = Dict{String,Any}()
+for prob in con_problems
+    local result
+    @show prob
+    try
+        result = solve_problem(prob, IPNewton())
+    catch
+        con_results[prob] = "failed"
+        continue
+    end
+    if result == Inf
+        println("Initial point is not in the interior")
+        continue
+    end
+    con_results[prob] = (Optim.converged(result), result.minimum, solution_optimum(prob), result.iterations, result.f_calls)
 end


### PR DESCRIPTION
I know these aren't run as actual tests (the lack of `@test` gives this away...), it's just handy to have the unconstrained example there as well. Since there aren't any tests, and the important calls are in a `try-catch` block, I didn't realize that I had failed to sync these with the change in API in the latest commit.