### PR TITLE
Add benchmarks: round 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,20 @@
-# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
-  - linux
+    - linux
+    - osx
 julia:
-  - 0.5
-  - nightly
-addons:
-  apt_packages:
-    - gfortran
-    - libgsl0-dev
+    - 0.6
+    - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
-  email: false
-sudo: required
-# uncomment the following lines to override the default test script
-before_install:
-    unset DYLD_LIBRARY_PATH;
-    sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/$(gfortran -dumpversion | cut -f1,2 -d.)/libgfortran.so /usr/local/lib
-
-#install:
-#  - julia -e 'Pkg.clone("https://github.com/optimizers/CUTEst.jl.git")'
-#  - julia -E 'Pkg.checkout("CUTEst", "develop"); Pkg.build("CUTEst");'
-
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("OptimTests"); Pkg.test("OptimTests"; coverage=true)'
-#after_success:
-  # push coverage results to Codecov
-#  - julia -e 'cd(Pkg.dir("OptimTests")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+    email: false
+sudo: false
+script:
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.test("Optim", coverage=true)'
+after_success:
+    - julia -e 'cd(Pkg.dir("Optim")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+    - julia -e 'Pkg.add("Documenter")'
+- julia -e 'cd(Pkg.dir("Optim")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 after_success:
     - julia -e 'cd(Pkg.dir("Optim")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
     - julia -e 'Pkg.add("Documenter")'
-- julia -e 'cd(Pkg.dir("Optim")); include(joinpath("docs", "make.jl"))'
+    - julia -e 'cd(Pkg.dir("Optim")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ NLPModels 0.0.1
 Optim
 CUTEst
 ProgressMeter
+DataFrames

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 NLPModels 0.0.1
 Optim
 CUTEst
+ProgressMeter

--- a/benchmarks/unconstrained/default/cutest_benchmarks.jl
+++ b/benchmarks/unconstrained/default/cutest_benchmarks.jl
@@ -1,0 +1,68 @@
+##########################################################################
+#
+# Benchmark optimization algorithms by tracking:
+#
+# * Number of iterations
+# * Number of f_calls
+# * Number of g_calls
+# * Memory requirements (TODO)
+#
+####
+# unconstrained
+options = Optim.Options()
+cutest_problems = CUTEst.select(max_var=10,contype = :unc, custom_filter=x->x["derivative_order"]>=2)
+n = length(default_solvers)
+m = length(cutest_problems)
+f = open(join([version_dir, "cutest_benchmark.csv"], "/"), "w")
+write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "f_hat", "f_error", "x_error"], ","))
+write(f, "\n")
+@showprogress 1 "Benchmarking..." for prob in cutest_problems
+    @show prob
+    output = []
+
+    nlp = CUTEstModel(prob)
+    x0 = initial_x(nlp)
+
+    x_hat = copy(x0)
+    f_hat = obj(nlp, x_hat)
+    xs = []
+    times = []
+        for i = 1:n
+        	try
+                d, constraints = optim_problem(nlp)
+        		result = optimize(d, default_solvers[i], options)
+                println(result)
+                mintime = @elapsed optimize(d, x0, default_solvers[i], options)
+                if f_hat > Optim.minimum(result)
+                    f_hat = Optim.minimum(result)
+                    x_hat[:] = Optim.minimizer(result)
+                end
+                push!(output, [prob,
+                               default_names[i],
+                               Optim.converged(result),
+                               mintime,
+                               Optim.minimum(result),
+                               Optim.iterations(result),
+                               Optim.f_calls(result),
+                               Optim.g_calls(result)])
+                push!(xs, Optim.minimizer(result))
+            catch
+                push!(output, ([prob,
+                               default_names[i],
+                               false,
+                               Inf,
+                               Inf,
+                               Inf,
+                               Inf,
+                               Inf]))
+                push!(xs, fill(Inf, length(x0)))
+        	end
+        end
+        for i = 1:n
+            write(f, join(map(x->"$x",output[i]),",")*",")
+            write(f, join(map(x->"$x",[f_hat, output[i][5]-f_hat, norm(xs[i]-x_hat, Inf)]),","))
+            write(f, "\n")
+        end
+    finalize(nlp)
+end
+close(f)

--- a/benchmarks/unconstrained/default/cutest_benchmarks.jl
+++ b/benchmarks/unconstrained/default/cutest_benchmarks.jl
@@ -14,7 +14,7 @@ cutest_problems = CUTEst.select(max_var=10,contype = :unc, custom_filter=x->x["d
 n = length(default_solvers)
 m = length(cutest_problems)
 f = open(join([version_dir, "cutest_benchmark.csv"], "/"), "w")
-write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "f_hat", "f_error", "x_error"], ","))
+write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "h_calls", "f_hat", "f_error", "x_error"], ","))
 write(f, "\n")
 @showprogress 1 "Benchmarking..." for prob in cutest_problems
     @show prob
@@ -45,11 +45,13 @@ write(f, "\n")
                                Optim.iterations(result),
                                Optim.f_calls(result),
                                Optim.g_calls(result)])
+                               Optim.h_calls(result)])
                 push!(xs, Optim.minimizer(result))
             catch
                 push!(output, ([prob,
                                default_names[i],
                                false,
+                               Inf,
                                Inf,
                                Inf,
                                Inf,

--- a/benchmarks/unconstrained/default/linesearch_benchmark_cutest.jl
+++ b/benchmarks/unconstrained/default/linesearch_benchmark_cutest.jl
@@ -1,0 +1,91 @@
+f = open(join([version_dir, "cutest_linesearch_benchmark.csv"], "/"), "w")
+write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "h_calls", "f_hat", "f_error", "x_error"], ","))
+write(f, "\n")
+
+options = Optim.Options(show_trace=true)
+cutest_problems = CUTEst.select(max_var=100,contype = :unc, custom_filter=x->x["derivative_order"]>=2)
+
+linesearch_solver_names = ["Accelerated Gradient Descent",
+                           "BFGS",
+                           "L-BFGS",
+                           "Conjugate Gradient",
+                           "Momentum Gradient Descent",
+                           "Gradient Descent",
+                           "Newton"]
+linesearch_solver_names = ["Newton",]
+
+linesearch_solvers =[AcceleratedGradientDescent,
+                            BFGS,
+                            LBFGS,
+                            ConjugateGradient,
+                            MomentumGradientDescent,
+                            GradientDescent,
+                            Newton]
+linesearch_solvers = [Newton, ]
+
+default_linesearches = [(LineSearches.BackTracking(order = 2), "BackTracking (quadratic)"),
+                        (LineSearches.BackTracking(order = 3), "BackTracking (cubic)"),
+                        (LineSearches.HagerZhang(), "HagerZhang"),
+                        (LineSearches.MoreThuente(), "MoreThuente"),
+                    #    (LineSearches.Static(alpha=0.1), "Static (alpha = 0.1)"),
+                    #    (LineSearches.Static(), "Static (alpha = 1)"),
+                        (LineSearches.StrongWolfe(), "StrongWolfe")]
+
+n = length(linesearch_solvers)
+m = length(cutest_problems)
+@showprogress 1 "Benchmarking..." for prob in cutest_problems
+if prob in ("STRATEC", "DMN37142LS", "DMN37143LS") # these take a looong time
+    continue
+end
+    @show prob
+    output = []
+
+    nlp = CUTEstModel(prob)
+    x0 = initial_x(nlp)
+
+    x_hat = copy(x0)
+    f_hat = obj(nlp, x_hat)
+    xs = []
+    times = []
+    for i = 1:n
+        for ls in default_linesearches
+        	try
+                d, constraints = optim_problem(nlp)
+        		result = optimize(d, linesearch_solvers[i](linesearch=ls[1]), options)
+                mintime = @elapsed optimize(d, x0, linesearch_solvers[i](linesearch=ls[1]), options)
+                if f_hat > Optim.minimum(result)
+                    f_hat = Optim.minimum(result)
+                    x_hat[:] = Optim.minimizer(result)
+                end
+                push!(output, [prob,
+                               linesearch_solver_names[i]*" with "*ls[2],
+                               Optim.converged(result),
+                               mintime,
+                               Optim.minimum(result),
+                               Optim.iterations(result),
+                               Optim.f_calls(result),
+                               Optim.g_calls(result),
+                               Optim.h_calls(result)])
+                push!(xs, Optim.minimizer(result))
+            catch
+                push!(output, ([prob,
+                               linesearch_solver_names[i]*" with "*ls[2],
+                               false,
+                               Inf,
+                               Inf,
+                               Inf,
+                               Inf,
+                               Inf,
+                               Inf]))
+                push!(xs, fill(Inf, length(x0)))
+        	end
+        end
+        for i = 1:length(default_linesearches)
+            write(f, join(map(x->"$x",output[i]),",")*",")
+            write(f, join(map(x->"$x",[f_hat, output[i][5]-f_hat, norm(xs[i]-x_hat, Inf)]),","))
+            write(f, "\n")
+        end
+    end
+    finalize(nlp)
+end
+close(f)

--- a/benchmarks/unconstrained/default/linesearch_benchmark_optim.jl
+++ b/benchmarks/unconstrained/default/linesearch_benchmark_optim.jl
@@ -1,0 +1,85 @@
+f = open(join([version_dir, "optim_linesearch_benchmark.csv"], "/"), "w")
+write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "h_call", "f_hat", "f_error", "x_error"], ","))
+write(f, "\n")
+
+linesearch_solver_names = ["Accelerated Gradient Descent",
+                           "BFGS",
+                           "L-BFGS",
+                           "Conjugate Gradient",
+                           "Momentum Gradient Descent",
+                           "Gradient Descent",
+                           "Newton"]
+linesearch_solver_names = ["Newton",]
+
+linesearch_solvers =[AcceleratedGradientDescent,
+                            BFGS,
+                            LBFGS,
+                            ConjugateGradient,
+                            MomentumGradientDescent,
+                            GradientDescent,
+                            Newton]
+linesearch_solvers = [Newton, ]
+
+default_linesearches = [(LineSearches.BackTracking(order = 2), "BackTracking (quadratic)"),
+                        (LineSearches.BackTracking(order = 3), "BackTracking (qubic)"),
+                        (LineSearches.HagerZhang(), "HagerZhang"),
+                        (LineSearches.MoreThuente(), "MoreThuente"),
+                        (LineSearches.Static(alpha=0.1), "Static (alpha = 0.1)"),
+                        (LineSearches.Static(), "Static (alpha = 1)"),
+                        (LineSearches.StrongWolfe(), "StrongWolfe")]
+
+@showprogress 1 "Benchmarking..." for (name, problem) in Optim.UnconstrainedProblems.examples
+    for (i,  algorithm) in enumerate(linesearch_solvers)
+        for ls in default_linesearches
+            print_debuginfo && @show name, problem , algorithm
+            try
+            # Force compilation and obtain results
+            results = optimize(problem.f, problem.g!, problem.h!,
+                               problem.initial_x, algorithm(linesearch=ls[1]), Optim.Options(g_tol = 1e-16))
+            # Run each algorithm n times
+            n = 10
+            if algorithm == ParticleSwarm() && name == "Large Polynomial"
+                n = 1
+            end
+            # Estimate run time in seconds
+            run_time = minimum([@elapsed optimize(problem.f, problem.g!, problem.h!,
+                                   problem.initial_x,
+                                   algorithm(linesearch=ls[1]), Optim.Options(g_tol = 1e-16)) for nn = 1:n])
+
+            # Count iterations
+            iterations = results.iterations
+
+            # Print out results.
+            write(f, join([problem.name,
+                           linesearch_solver_names[i]*" with "*ls[2],
+                           Optim.converged(results),
+                           run_time,
+                           Optim.minimum(results),
+                           iterations,
+                           Optim.f_calls(results),
+                           Optim.g_calls(results),
+                           Optim.h_calls(results),
+                           problem.f(problem.solutions),
+                           Optim.minimum(results)-problem.f(problem.solutions),
+                           norm(Optim.minimizer(results)-problem.solutions, Inf)], ","))
+            write(f, "\n")
+            catch m
+                println(m)
+                write(f, join([problem.name,
+                               linesearch_solver_names[i]*" with "*ls[2],
+                               "false",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf"], ","))
+                write(f, "\n")
+            end
+        end
+    end
+end
+close(f)

--- a/benchmarks/unconstrained/default/optim_benchmarks.jl
+++ b/benchmarks/unconstrained/default/optim_benchmarks.jl
@@ -1,0 +1,54 @@
+    f = open(join([version_dir, "optim_benchmark.csv"], "/"), "w")
+    write(f, join(["Problem", "Optimizer", "Converged", "Time", "Minimum", "Iterations", "f_calls", "g_calls", "f_hat", "f_error", "x_error"], ","))
+    write(f, "\n")
+
+    @showprogress 1 "Benchmarking..." for (name, problem) in Optim.UnconstrainedProblems.examples
+        for (i,  algorithm) in enumerate(default_solvers)
+            print_debuginfo && @show name, problem , algorithm
+            try
+            # Force compilation and obtain results
+            results = optimize(problem.f, problem.g!, problem.h!,
+                               problem.initial_x, algorithm, Optim.Options(g_tol = 1e-16))
+            # Run each algorithm n times
+            n = 10
+            if algorithm == ParticleSwarm() && name == "Large Polynomial"
+                n = 1
+            end
+            # Estimate run time in seconds
+            run_time = minimum([@elapsed optimize(problem.f, problem.g!, problem.h!,
+                                   problem.initial_x,
+                                   algorithm, Optim.Options(g_tol = 1e-16)) for nn = 1:n])
+
+            # Count iterations
+            iterations = results.iterations
+
+            # Print out results.
+            write(f, join([problem.name,
+                           default_names[i],
+                           Optim.converged(results),
+                           run_time,
+                           Optim.minimum(results),
+                           iterations,
+                           Optim.f_calls(results),
+                           Optim.g_calls(results),
+                           problem.f(problem.solutions),
+                           Optim.minimum(results)-problem.f(problem.solutions),
+                           norm(Optim.minimizer(results)-problem.solutions, Inf)], ","))
+            write(f, "\n")
+            catch
+                write(f, join([problem.name,
+                               default_names[i],
+                               "false",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf",
+                               "Inf"], ","))
+                write(f, "\n")
+            end
+        end
+    end
+    close(f)

--- a/benchmarks/unconstrained/run_benchmarks.jl
+++ b/benchmarks/unconstrained/run_benchmarks.jl
@@ -44,3 +44,6 @@ default_solvers =[AcceleratedGradientDescent(),
 
 do_benchmarks && include("$(Pkg.dir("OptimTests"))"*"/benchmarks/unconstrained/default/cutest_benchmarks.jl")
 saveplots && save_plots(version_dir, :cutest)
+
+do_benchmarks && include("$(Pkg.dir("OptimTests"))"*"/benchmarks/unconstrained/default/linesearch_benchmark_optim.jl")
+saveplots && save_plots(version_dir, :cutest_linesearch)

--- a/benchmarks/unconstrained/run_benchmarks.jl
+++ b/benchmarks/unconstrained/run_benchmarks.jl
@@ -1,0 +1,46 @@
+using Optim, OptimTests, CUTEst, ProgressMeter, Plots, DataFrames, BenchmarkTools
+
+do_benchmarks = true
+saveplots = true
+print_debuginfo = false
+
+pkg_dir = Pkg.dir("OptimTests")
+version_sha = latest_commit("OptimTests")
+benchmark_dir = pkg_dir*"/benchmarks/unconstrained/history/"
+version_dir = benchmark_dir*version_sha
+try
+    run(`mkdir $version_dir`)
+catch
+
+end
+cd(version_dir)
+
+default_names = ["Accelerated Gradient Descent",
+                 "BFGS",
+                 "L-BFGS",
+                 "Conjugate Gradient",
+                 "Momentum Gradient Descent",
+                 "Gradient Descent",
+                 "Nelder-Mead",
+                 "Particle Swarm",
+                 "Simulated Annealing",
+                 "Newton",
+                 "Newton (Trust Region)"]
+
+default_solvers =[AcceleratedGradientDescent(),
+                BFGS(),
+                LBFGS(),
+                ConjugateGradient(),
+                MomentumGradientDescent(),
+                GradientDescent(),
+                NelderMead(),
+                ParticleSwarm(),
+                SimulatedAnnealing(),
+                Newton(),
+                NewtonTrustRegion()]
+
+#do_benchmarks && include("$(Pkg.dir("OptimTests"))"*"/benchmarks/unconstrained/default/optim_benchmarks.jl")
+#saveplots && save_plots(version_dir, :optim)
+
+do_benchmarks && include("$(Pkg.dir("OptimTests"))"*"/benchmarks/unconstrained/default/cutest_benchmarks.jl")
+saveplots && save_plots(version_dir, :cutest)

--- a/src/OptimTests.jl
+++ b/src/OptimTests.jl
@@ -1,8 +1,11 @@
 module OptimTests
 
-using Optim, CUTEst
+using Optim, CUTEst, DataFrames, Plots
 
-export optim_problem, initial_x, solve_problem, solution_optimum, eqconstraints_violation
+export optim_problem, initial_x, solve_problem, solution_optimum, eqconstraints_violation,
+       latest_commit, profiles, save_plots
+
+include("benchmarks.jl")
 
 function symmetrize!(h)
     for j = 1:size(h,2)

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -1,0 +1,63 @@
+# Get the latest commit as a string due to Ismael Venegas Castelló (@Ismael-VC)
+"""
+Returns the shortened SHA of the latest commit of a package.
+"""
+function latest_commit(pkg::String)::String
+    original_directory = pwd()
+    cd(Pkg.dir(pkg))
+    commit = readstring(`git rev-parse --short HEAD`) |> chomp
+    cd(original_directory)
+    return commit
+end
+
+
+"""
+Returns, for each solver, a vector of counts of the number of problems in the DataFrame
+that is below the threshold values given.
+"""
+function profiles(names, df, tau, measure)
+    profiles_out = []
+    for name in names
+        profile = zeros(tau)
+        rows =  df[:Optimizer].==name
+        for i = 1:length(tau)
+            profile[i] = sum(df[rows, measure].<=tau[i])/length(unique(df[:Problem]))
+        end
+        push!(profiles_out, profile)
+    end
+    profiles_out
+end
+
+"""
+Saves two figures showing performance profiles for the objective error and the
+error in the minimizer across problems and solvers.
+"""
+function save_plots(version_dir, testset; tau = 10.0.^(-16:10), legendpos = :bottomright)
+    teststr = testset == :cutest ? "cutest" : "optim"
+    str = version_dir*"/"*teststr*"_benchmark.csv"
+    df = readtable(str)
+    names = unique(df[:Optimizer])
+    f_profiles = profiles(names, df, tau, :f_error)
+    f_err = plot(tau, hcat(f_profiles...),
+            label = hcat(names...),
+            lc=[:black :red :green :black :red :green :black :red :green :black :red :green],
+            ls=[:solid  :solid :solid :dash :dash :dash :dashdot :dashdot :dashdot :dot :dot :dot],
+            size =(800,400),
+            ylims = (0,1),
+            line = :steppre, xscale=:log10, xlabel = "Error level", ylabel = "Proportion of problems",
+            title = "Measure: f-f*",
+            legend=legendpos)
+    savefig("f_err_"*teststr)
+
+    x_profiles = profiles(names, df, tau, :x_error)
+    x_err = plot(tau, hcat(x_profiles...),
+            label = hcat(names...),
+            lc=[:black :red :green :black :red :green :black :red :green :black :red :green],
+            ls=[:solid  :solid :solid :dash :dash :dash :dashdot :dashdot :dashdot :dot :dot :dot],
+            size =(800,400),
+            ylims = (0,1),
+            line = :steppre, xscale=:log10, xlabel = "Error level", ylabel = "Proportion of problems",
+            title = "Measure: sup-norm of x-x*.",
+            legend=legendpos)
+    savefig("x_err_"*teststr)
+end

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -33,7 +33,19 @@ Saves two figures showing performance profiles for the objective error and the
 error in the minimizer across problems and solvers.
 """
 function save_plots(version_dir, testset; tau = 10.0.^(-16:10), legendpos = :bottomright)
-    teststr = testset == :cutest ? "cutest" : "optim"
+
+    if testset == :cutest
+        teststr = "cutest"
+    elseif testset == :optim
+        teststr = "optim"
+    elseif testset == :optim_linesearch
+        teststr = "optim_linesearch"
+    elseif testset == :cutest_linesearch
+        teststr = "cutest_linesearch"
+    else
+        err("Symbol not supported")
+    end
+
     str = version_dir*"/"*teststr*"_benchmark.csv"
     df = readtable(str)
     names = unique(df[:Optimizer])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ options = Optim.Options(store_trace=true)
 unc_problems = CUTEst.select(max_var=10,contype = :unc, custom_filter=x->x["derivative_order"]>=2)
 unc_results = Dict{String,Any}()
 for prob in unc_problems
+    #if !(endswith(prob, "LS")) && !(prob in ("KOWOSBNE", "SSI"))
     local result
     @show prob
     nlp = CUTEstModel(prob)
@@ -48,6 +49,7 @@ for prob in unc_problems
     end
     unc_results[prob] = (Optim.converged(result), result.minimum, solution_optimum(prob), result.iterations, result.f_calls)
     finalize(nlp)
+#    end
 end
 @test sum(v=="failed" for v in values(unc_results)) < length(unc_results)
 #=


### PR DESCRIPTION
I'll run the benchmarks on master Optim, but for C^2 functions, we see the usual newton+(l)bfgs methods come out on top. I'll add some "per method" line search benchmarks to see if we should maybe change the defaults in some places (if I remember correctly, MoreThuente came out on top for bfgs when I did this earlier).